### PR TITLE
Fixed broken link to Smoothing_surfaces notebook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ These are IPython Notebooks. They can be opened and read in their raw format, or
 
 ## February 2014
 - [Filtering horizons and attributes](http://library.seg.org/toc/leedff/33/2), by Matt Hall
-- [IPython Notebook](http://nbviewer.org/github/seg/tutorials/blob/master/1402_Filtering_horizons.ipynb)
+- [IPython Notebook](http://nbviewer.ipython.org/github/seg/tutorials/blob/master/1402_Smoothing_surfaces.ipynb)
 


### PR DESCRIPTION
The link was using an old version of the notebook name in nbviewer.
