### PR TITLE
Fix broken link to the PDF of Steve Purves

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ These are IPython Notebooks. They can be opened and read in their raw format, or
 ## October 2014
 - Phase and the Hilbert transform (link to follow), By Steve Purves -- article in *TLE*
 - [A guide to running the tutorial with GNU Octave](1410_Phase/readme.md)
-- [A longer version of the tutorial paper](1410_phase/purves_tutorial_long.pdf)
+- [A longer version of the tutorial paper](https://github.com/seg/tutorials/raw/master/1410_Phase/purves_tutorial_long.pdf)


### PR DESCRIPTION
The dir name in the link needed to be capitalized. 
A link to the raw file makes it easier to download the PDF.
